### PR TITLE
Fix explicit conversions for Mutagen links

### DIFF
--- a/MagicDoesThings/ScrollPatcher.cs
+++ b/MagicDoesThings/ScrollPatcher.cs
@@ -200,7 +200,7 @@ internal class ScrollPatcher
                         {
                             CompareOperator = CompareOperator.EqualTo,
                             ComparisonValue = 1,
-                            Data = effectConditionData
+                            Data = (ConditionData)effectConditionData
                         }
                     }
                 },
@@ -215,7 +215,7 @@ internal class ScrollPatcher
                             ComparisonValue = 1,
                             Data = new GetIsIDConditionData
                             {
-                                Object = spell,
+                                Object = (IFormLinkOrIndex<IReferenceableObjectGetter>)spell,
                                 RunOnType = Condition.RunOnType.Subject
                             }
                         }
@@ -229,12 +229,12 @@ internal class ScrollPatcher
 
         HasMagicEffectConditionData firstFunctionConditionData = new()
         {
-            MagicEffect = firstEffect.ToLink(),
+            MagicEffect = (IFormLinkOrIndex<IMagicEffectGetter>)firstEffect.ToLink(),
             RunOnType = Condition.RunOnType.Subject
         };
         HasMagicEffectConditionData secondFunctionConditionData = new()
         {
-            MagicEffect = secondEffect.ToLink(),
+            MagicEffect = (IFormLinkOrIndex<IMagicEffectGetter>)secondEffect.ToLink(),
             RunOnType = Condition.RunOnType.Subject
         };
 
@@ -295,7 +295,7 @@ internal class ScrollPatcher
             ComparisonValue = 1,
             Data = new HasSpellConditionData()
             {
-                Spell = spell,
+                Spell = (IFormLinkOrIndex<ISpellGetter>)spell,
                 RunOnType = Condition.RunOnType.Subject
             }
         });

--- a/MagicDoesThings/StaffPatcher.cs
+++ b/MagicDoesThings/StaffPatcher.cs
@@ -199,8 +199,8 @@ internal class StaffPatcher
                 Console.WriteLine($"ERROR: failed to get condition data from {perk}");
                 return false;
             }
-            firstConditionData.MagicEffect = lensEffect.ToLink();
-            secondConditionData.FormList = formList.ToLink();
+            firstConditionData.MagicEffect = (IFormLinkOrIndex<IMagicEffectGetter>)lensEffect.ToLink();
+            secondConditionData.FormList = (IFormLinkOrIndex<IFormListGetter>)formList.ToLink();
         }
 
         _state.PatchMod.ObjectEffects.Add(objectEffect);


### PR DESCRIPTION
## Summary
- fix missing casts when assigning form links to `IFormLinkOrIndex` and `ConditionData`

## Testing
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6887937e8df4832d843c7ba16e38c320